### PR TITLE
Ensure PyInstaller dependency is checked

### DIFF
--- a/scripts/check_update/build_exe.py
+++ b/scripts/check_update/build_exe.py
@@ -12,6 +12,7 @@ REQUIRED = {
     'keyboard': 'keyboard',
     'PIL': 'pillow',
     'win32api': 'pywin32',
+    'PyInstaller': 'pyinstaller',
 }
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- include PyInstaller in dependency checks

## Testing
- `python -m py_compile scripts/check_update/build_exe.py`


------
https://chatgpt.com/codex/tasks/task_e_687ba34bc4f48333bfb9dd4de16fe7ae