### PR TITLE
Fix paths in gui_downloader.spec

### DIFF
--- a/gui_downloader.spec
+++ b/gui_downloader.spec
@@ -2,10 +2,10 @@
 
 
 a = Analysis(
-    ['gui_downloader.py'],
+    ['scripts/gui_downloader.py'],
     pathex=[],
     binaries=[],
-    datas=[('ico.ico', '.'), ('act.ico', '.'), ('dw.ico', '.'), ('config.ini', '.')],
+    datas=[('ico', 'ico'), ('assets', 'assets'), ('system', 'system')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},
@@ -35,5 +35,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=['ico.ico'],
+    icon=['ico/ico.ico'],
 )


### PR DESCRIPTION
## Summary
- use `scripts/gui_downloader.py` instead of top-level file
- include entire directories for assets in PyInstaller spec
- update icon path to match folder structure

## Testing
- `python -m py_compile scripts/gui_downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_687ba3c37d9083339b2e06aff5dd0471